### PR TITLE
Fixes Corners on Cards

### DIFF
--- a/client/css/widgets/card.css
+++ b/client/css/widgets/card.css
@@ -1,3 +1,8 @@
+.card {
+  /* exact function uncertain but improves visibility of some card corners */
+  overflow: hidden;
+}
+
 body.edit .card {
   display: none;
 }


### PR DESCRIPTION
Fixes card corner visibility errors caused by PR#226.  Closes #240.

I acknowledge robartsd's comments about needing to understand this better and looking for a better solution.  However, this band-aid solution will work in the interim.  Playing with those card corners is very visually distracting.